### PR TITLE
[주요 변경 사항]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,19 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.18.2</version> <!-- 최신 버전으로 교체 -->
         </dependency>
+
+        <!-- Apache POI for Excel -->
+        <!-- Excel 생성 의존성 -->
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi</artifactId>
+            <version>5.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-ooxml</artifactId>
+            <version>5.3.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/jobmoa/app/view/participant/UpdateController.java
+++ b/src/main/java/com/jobmoa/app/view/participant/UpdateController.java
@@ -16,6 +16,7 @@ import com.jobmoa.app.view.function.InfoBean;
 import jakarta.servlet.http.HttpSession;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -155,7 +156,7 @@ public class UpdateController {
 
     //update Mappings
     @PostMapping("/updatebasic.login")
-    public String update(Model model, HttpSession session, BasicDTO basicDTO, ParticcertifDTO particcertifDTO){
+    public String update(Model model, int page, HttpSession session, BasicDTO basicDTO, ParticcertifDTO particcertifDTO){
         //업데이트 여부에 따라 페이지가 다르기 때문에 각 변수를 선언
         String url = "updatebasic.login";
         String icon = "seuccess";
@@ -207,6 +208,11 @@ public class UpdateController {
             message = "자격증 등록중 문제가 발생했습니다.";
         }
 
+        //page 값이 0보다 크다면 추가후 이동
+        if(page > 0){
+            url += "?page="+page;
+        }
+
         //확인용 로그
         InfoBean.info(model, url, icon, title, message);
 
@@ -214,7 +220,7 @@ public class UpdateController {
     }
 
     @PostMapping("/updatecounsel.login")
-    public String update(Model model, HttpSession session, BasicDTO basicDTO, CounselDTO counselDTO, EducationDTO educationDTO){
+    public String update(Model model, int page, HttpSession session, BasicDTO basicDTO, CounselDTO counselDTO, EducationDTO educationDTO){
         //info 페이지로 넘길 변수 선언
         String url = "updatecounsel.login";
         String icon = "";
@@ -234,7 +240,7 @@ public class UpdateController {
 
             //구직번호가 없다면 오류를 반환하고 조회페이지로 반환
             log.info("상담정보 jobNo : [{}]", jobNo);
-            if(jobNo <= 0 && counselJobNo <= 0){
+            if(jobNo <= 0){
                 url = "participant.login";
                 icon = "error";
                 title = "구직번호를 찾을 수 없습니다.";
@@ -292,13 +298,17 @@ public class UpdateController {
             educationService.insert(educationDTO);
         }
 
+        //page 값이 0보다 크다면 추가후 이동
+        if(page > 0){
+            url += "?page="+page;
+        }
         InfoBean.info(model, url, icon, title, message);
 
         return "views/info";
     }
 
     @PostMapping("/updateemployment.login")
-    public String update(Model model, HttpSession session, BasicDTO basicDTO, EmploymentDTO employmentDTO, CounselDTO counselDTO){
+    public String update(Model model, int page, HttpSession session, BasicDTO basicDTO, EmploymentDTO employmentDTO, CounselDTO counselDTO){
         //info 페이지로 넘길 변수 선언
         String url = "updateemployment.login";
         String icon = "";
@@ -343,6 +353,11 @@ public class UpdateController {
                 icon = "error";
                 title = "취업정보 추가 실패";
             }
+        }
+
+        //page 값이 0보다 크다면 추가후 이동
+        if(page > 0){
+            url += "?page="+page;
         }
 
         InfoBean.info(model, url, icon, title, message);
@@ -423,7 +438,7 @@ public class UpdateController {
 
 
     @PostMapping("/participantUpdate.login")
-    public String update(Model model, HttpSession session, BasicDTO basicDTO, EmploymentDTO employmentDTO,
+    public String update(Model model, int page, HttpSession session, BasicDTO basicDTO, EmploymentDTO employmentDTO,
                          CounselDTO counselDTO, EducationDTO educationDTO, ParticcertifDTO particcertifDTO){
         String url = "participant.login";
         String icon = "success";
@@ -451,6 +466,12 @@ public class UpdateController {
             icon="error";
             title="참여자 업데이트 실패";
             message="참여자 번호 : "+jobNo;
+        }
+
+        log.info("test [{}]",page);
+        //page 값이 0보다 크다면 page 값을 추가후 이동
+        if(page > 0){
+            url += "?page="+page;
         }
 
         //update 완료 여부를 확인해 info page로 정보를 전달한다.

--- a/src/main/java/com/jobmoa/app/view/report/DailyWorkReport.java
+++ b/src/main/java/com/jobmoa/app/view/report/DailyWorkReport.java
@@ -1,16 +1,283 @@
+// 패키지 선언
 package com.jobmoa.app.view.report;
 
+// 필요한 라이브러리 임포트
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.ss.util.CellRangeAddress;
+import org.apache.poi.ss.util.CellReference;
+import org.apache.poi.ss.util.RegionUtil;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
+// Lombok 로깅 어노테이션과 스프링 컨트롤러 어노테이션
 @Slf4j
 @Controller
 public class DailyWorkReport {
+    // 엑셀 관련 상수 정의
+    private static final String SHEET_NAME = "국민취업지원제도 업무진행현황";
+    private static final String FILE_PREFIX = "국민취업지원제도_일일업무일지_";
+    private static final String DATE_FORMAT_PATTERN = "yyyy년 MM월 dd일 E요일";
+    private static final int DEFAULT_COLUMN_WIDTH = 17;
+    private static final short DEFAULT_COLUMN_HEIGHT = 517;
 
+    // 셀 병합 범위 정의
+    private static final String[] CELL_MERGE_RANGES = {
+            //report title
+            "A1:M2", "A3:M3", "N1:N3", "O2:O3", "P2:P3", "Q2:Q3",
+            //report 1. 배정 현황
+            "A4:Q4", "A5:F7", "G5:J7", "L5:N7", "K5:k7", "O5:Q7",
+            "A8:B8", "C8:D8", "E8:F8", "A9:B9", "C9:D9", "E9:F9",
+            "G8:H8", "I8:J8", "G9:H9", "I9:J9", "K8:K9", "L8:N9",
+            "O8:Q9",
+            //report 2. 알선취업 성과 현황
+            "A10:Q10", "B11:E11", "B12:C12", "D12:E12",
+            "F11:I11", "F12:G12", "H12:I12",
+            "J11:M11", "J12:K12", "L12:M12",
+            "N11:Q11", "N12:O12", "P12:Q12",
+            "B13:C13", "D13:E13", "F13:G13", "H13:I13", "J13:K13", "L13:M13", "N13:O13", "P13:Q13",
+            "B14:C14", "D14:E14", "F14:G14", "H14:I14", "J14:K14", "L14:M14", "N14:O14", "P14:Q14",
+            "B15:C15", "D15:E15", "F15:G15", "H15:I15", "J15:K15", "L15:M15", "N15:O15", "P15:Q15",
+            "B16:C16", "D16:E16", "F16:G16", "H16:I16", "J16:K16", "L16:M16", "N16:O16", "P16:Q16",
+            "B17:C17", "D17:E17", "F17:G17", "H17:I17", "J17:K17", "L17:M17", "N17:O17", "P17:Q17",
+            "B18:C18", "D18:E18", "F18:G18", "H18:I18", "J18:K18", "L18:M18", "N18:O18", "P18:Q18",
+            "B19:C19", "D19:E19", "F19:G19", "H19:I19", "J19:K19", "L19:M19", "N19:O19", "P19:Q19",
+            "B20:C20", "D20:E20", "F20:G20", "H20:I20", "J20:K20", "L20:M20", "N20:O20", "P20:Q20",
+            "B21:C21", "D21:E21", "F21:G21", "H21:I21", "J21:K21", "L21:M21", "N21:O21", "P21:Q21",
+            "B22:C22", "D22:E22", "F22:G22", "H22:I22", "J22:K22", "L22:M22", "N22:O22", "P22:Q22",
+            "B23:C23", "D23:E23", "F23:G23", "H23:I23", "J23:K23", "L23:M23", "N23:O23", "P23:Q23"
+            //Report 3. 총괄 진행현황
+            //Report 4. 기타사항
+    };
+
+    // 테두리를 적용할 단일 셀 정의
+    private static final String[] BORDER_CELLS = {
+            "N1:N3", "O2:O3", "P2:P3", "Q2:Q3", "O1", "P1", "Q1",
+            //report 1. 배정 현황
+            "A4:Q4", "A5:F7", "G5:J7", "L5:N7", "K5:k7", "O5:Q7",
+            "A8:B8", "C8:D8", "E8:F8", "A9:B9", "C9:D9", "E9:F9",
+            "G8:H8", "I8:J8", "G9:H9", "I9:J9", "K8:K9", "L8:N9",
+            "O8:Q9",
+            //report 2. 알선취업 성과 현황
+            "A11","A12","A13","A14","A15","A16","A17","A18","A19","A20","A21","A22","A23",
+            "A10:Q10", "B11:E11", "B12:C12", "D12:E12",
+            "F11:I11", "F12:G12", "H12:I12",
+            "J11:M11", "J12:K12", "L12:M12",
+            "N11:Q11", "N12:O12", "P12:Q12",
+            "B13:C13", "D13:E13", "F13:G13", "H13:I13", "J13:K13", "L13:M13", "N13:O13", "P13:Q13",
+            "B14:C14", "D14:E14", "F14:G14", "H14:I14", "J14:K14", "L14:M14", "N14:O14", "P14:Q14",
+            "B15:C15", "D15:E15", "F15:G15", "H15:I15", "J15:K15", "L15:M15", "N15:O15", "P15:Q15",
+            "B16:C16", "D16:E16", "F16:G16", "H16:I16", "J16:K16", "L16:M16", "N16:O16", "P16:Q16",
+            "B17:C17", "D17:E17", "F17:G17", "H17:I17", "J17:K17", "L17:M17", "N17:O17", "P17:Q17",
+            "B18:C18", "D18:E18", "F18:G18", "H18:I18", "J18:K18", "L18:M18", "N18:O18", "P18:Q18",
+            "B19:C19", "D19:E19", "F19:G19", "H19:I19", "J19:K19", "L19:M19", "N19:O19", "P19:Q19",
+            "B20:C20", "D20:E20", "F20:G20", "H20:I20", "J20:K20", "L20:M20", "N20:O20", "P20:Q20",
+            "B21:C21", "D21:E21", "F21:G21", "H21:I21", "J21:K21", "L21:M21", "N21:O21", "P21:Q21",
+            "B22:C22", "D22:E22", "F22:G22", "H22:I22", "J22:K22", "L22:M22", "N22:O22", "P22:Q22",
+            "B23:C23", "D23:E23", "F23:G23", "H23:I23", "J23:K23", "L23:M23", "N23:O23", "P23:Q23"
+            //Report 3. 총괄 진행현황
+            //Report 4. 기타사항
+    };
+
+    // 보고서 페이지 요청 처리
     @GetMapping("report.login")
-    public String reportPage(){
+    public String reportPage() {
         return "views/DailyWorkReportPage";
     }
 
+    // 엑셀 다운로드 요청 처리
+    @GetMapping("downloadExcel.login")
+    public void downloadExcel(HttpServletResponse response) throws IOException {
+        // try-with-resources를 사용하여 워크북 자동 닫기
+        try (Workbook workbook = createWorkbook()) {
+            setupResponse(response, generateFileName());
+            workbook.write(response.getOutputStream());
+        }
+    }
+
+    // 워크북 생성 및 초기 설정
+    private Workbook createWorkbook() {
+        Workbook workbook = new XSSFWorkbook();
+        Sheet sheet = workbook.createSheet(SHEET_NAME);
+        sheet.setDefaultColumnWidth(DEFAULT_COLUMN_WIDTH);
+        sheet.setDefaultRowHeight(DEFAULT_COLUMN_HEIGHT);
+
+        CellStyle centerStyle = createCenterAlignedStyle(workbook);
+        CellStyle leftStyle = createCenterAlignedStyle(workbook);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN, Locale.KOREAN);
+
+        //Report Creat Start
+
+        //Report Header
+        createTitle(sheet, centerStyle, formatter);
+
+        //Report 1. 배정 현황
+        createAssignmentStatusReport(sheet, leftStyle);
+
+        //Report 2. 알선취업 성과 현황
+        createEmploymentPerformanceReport(sheet, centerStyle);
+
+        //Report 3. 총괄 진행현황
+        createOverallProgressReport(sheet, centerStyle);
+
+        //Report 4. 기타사항
+        createMiscellaneousReport(sheet, centerStyle);
+
+        //Report Creat End
+
+        applyMergesAndBorders(sheet);
+
+        return workbook;
+    }
+
+    // 가운데 정렬 스타일 생성
+    private CellStyle createCenterAlignedStyle(Workbook workbook) {
+        CellStyle style = workbook.createCellStyle();
+        style.setAlignment(HorizontalAlignment.CENTER);
+        style.setVerticalAlignment(VerticalAlignment.CENTER);
+        return style;
+    }
+
+    // 왼쪽 정렬 스타일 생성
+    private CellStyle createLeftAlignedStyle(Workbook workbook) {
+        CellStyle style = workbook.createCellStyle();
+        style.setAlignment(HorizontalAlignment.LEFT);
+        style.setVerticalAlignment(VerticalAlignment.CENTER);
+        return style;
+    }
+
+    // 제목 및 헤더 생성
+    private void createTitle(Sheet sheet, CellStyle style, DateTimeFormatter formatter) {
+        setCellValue(sheet, 0, "A", "지점 국민취업지원제도 업무진행현황 일일보고", style);
+        setCellValue(sheet, 2, "A", LocalDateTime.now().format(formatter), style);
+        setCellValue(sheet, 0, "N", "결\n재", style);
+        setCellValue(sheet, 0, "O", "지점관리자", style);
+        setCellValue(sheet, 0, "P", "대표", style);
+        setCellValue(sheet, 0, "Q", "회장", style);
+    }
+
+    //Report 1. 배정 현황
+    private void createAssignmentStatusReport(Sheet sheet, CellStyle style){
+        setCellValue(sheet,3,"A","1. 배정 현황",style);
+        setCellValue(sheet,4,"A","2024년 총 서비스 대상 인원(전산 배정 인원)",style);
+        setCellValue(sheet,7,"A","합계",style);
+        setCellValue(sheet,8,"A","",style);
+        setCellValue(sheet,7,"C","Ⅱ유형",style);
+        setCellValue(sheet,8,"C","",style);
+        setCellValue(sheet,7,"E","Ⅰ유형",style);
+        setCellValue(sheet,8,"E","",style);
+        setCellValue(sheet,4,"G","금일 배정인원",style);
+        setCellValue(sheet,7,"G","Ⅱ유형",style);
+        setCellValue(sheet,8,"G","",style);
+        setCellValue(sheet,7,"I","Ⅰ유형",style);
+        setCellValue(sheet,8,"I","",style);
+        setCellValue(sheet,4,"K","상담사수",style);
+        setCellValue(sheet,7,"K","",style);
+        setCellValue(sheet,4,"L","평균\n배정인원",style);
+        setCellValue(sheet,7,"L","",style);
+        setCellValue(sheet,4,"O","배정목표",style);
+        setCellValue(sheet,7,"O","100",style);
+    }
+
+    //Report 2. 알선취업 성과 현황
+    private void createEmploymentPerformanceReport(Sheet sheet, CellStyle style){
+        setCellValue(sheet,9,"A","2. 알선취업 성과 현황",style);
+        setCellValue(sheet,10,"A","구분",style);
+        setCellValue(sheet,11,"A","상담사",style);
+        setCellValue(sheet,10,"B","금일 누적 실적",style);
+        setCellValue(sheet,11,"B","일반 취업",style);
+        setCellValue(sheet,11,"D","알선 취업",style);
+        setCellValue(sheet,10,"F","금주 누적 실적",style);
+        setCellValue(sheet,11,"F","일반 취업",style);
+        setCellValue(sheet,11,"H","알선 취업",style);
+        setCellValue(sheet,10,"J","금월 누적 실적",style);
+        setCellValue(sheet,11,"J","일반 취업",style);
+        setCellValue(sheet,11,"L","알선 취업",style);
+        setCellValue(sheet,10,"N","금년 누적 실적",style);
+        setCellValue(sheet,11,"N","일반 취업",style);
+        setCellValue(sheet,11,"P","알선 취업",style);
+        setCellValue(sheet,22,"A","합계",style);
+
+    }
+
+    //Report 3. 총괄 진행현황
+    private void createOverallProgressReport(Sheet sheet, CellStyle style){
+
+    }
+
+    //Report 4. 기타사항
+    private void createMiscellaneousReport(Sheet sheet, CellStyle style){
+
+    }
+
+    // 셀 값 설정 헬퍼 메소드
+    private void setCellValue(Sheet sheet, int rowNum, String colLetter, String value, CellStyle style) {
+        Cell cell = getCell(sheet, rowNum, CellReference.convertColStringToIndex(colLetter));
+        cell.setCellValue(value);
+        cell.setCellStyle(style);
+    }
+
+    // 셀 병합 및 테두리 적용
+    private void applyMergesAndBorders(Sheet sheet) {
+        // 셀 병합 및 테두리 범위에 대한 처리
+        // 셀 병합 적용
+        for (String range : CELL_MERGE_RANGES) {
+                CellRangeAddress rangeAddress = CellRangeAddress.valueOf(range);
+                sheet.addMergedRegion(rangeAddress);
+        }
+
+        // 셀 테두리 적용
+        for (String cell : BORDER_CELLS) {
+            applyBorders(sheet, CellRangeAddress.valueOf(cell));
+        }
+    }
+
+    // 테두리 스타일 적용
+    private void applyBorders(Sheet sheet, CellRangeAddress range) {
+        RegionUtil.setBorderBottom(BorderStyle.THIN, range, sheet);
+        RegionUtil.setBorderTop(BorderStyle.THIN, range, sheet);
+        RegionUtil.setBorderLeft(BorderStyle.THIN, range, sheet);
+        RegionUtil.setBorderRight(BorderStyle.THIN, range, sheet);
+    }
+
+    // 셀 생성 또는 가져오기
+    private Cell getCell(Sheet sheet, int rownum, int cellnum) {
+        Row row = getRow(sheet,rownum);
+
+        Cell cell = row.getCell(cellnum);
+        if (cell == null) {
+            cell = row.createCell(cellnum);
+        }
+        return cell;
+    }
+
+    private Row getRow(Sheet sheet, int rownum) {
+        Row row = sheet.getRow(rownum);
+        if (row == null) {
+            row = sheet.createRow(rownum);
+        }
+        return row;
+    }
+
+    // 파일명 생성
+    private String generateFileName() {
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN, Locale.KOREAN));
+        return URLEncoder.encode(FILE_PREFIX + timestamp + ".xlsx", StandardCharsets.UTF_8)
+                .replaceAll("\\+", "%20");
+    }
+
+    // HTTP 응답 설정
+    private void setupResponse(HttpServletResponse response, String fileName) {
+        response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+        response.setHeader("Content-Disposition", "attachment;filename=\"" + fileName + "\"");
+        response.setHeader("Content-Transfer-Encoding", "binary");
+    }
 }

--- a/src/main/resources/mappings/Dashboard-mapping.xml
+++ b/src/main/resources/mappings/Dashboard-mapping.xml
@@ -155,19 +155,21 @@
 
     <!-- 전담자 금일 업무 현황 시작 -->
     <select id="selectDailyDashboard" resultType="dashboard">
-        --15일 기준 최근상담일, 구직만료일, 기간만료일 전체 데이터
+        --21일 기준 최근상담일,
+        --15일 기준 구직만료일, 기간만료일 전체 데이터
         SELECT
-            -- 최근 상담일 15일 도래자
-            SUM(IIF(DATEDIFF(DAY, 최근상담일, GETDATE()) <![CDATA[>=]]> 15 AND 최근상담일 <![CDATA[<>]]> '', 1, 0)) AS dashBoardLastCons,
+            -- 최근 상담일 21일 도래자
+            SUM(IIF(DATEDIFF(DAY, 최근상담일, GETDATE()) <![CDATA[>=]]> 21 AND 최근상담일 <![CDATA[<>]]> '', 1, 0)) AS dashBoardLastCons,
             -- 구직 만료일 15일 도래자
             SUM(IIF(DATEDIFF(DAY, GETDATE(), 구직만료일) <![CDATA[<=]]> 15 AND 구직만료일 <![CDATA[<>]]> '', 1, 0)) AS dashBoardJobEX,
             -- 기간 만료일 15일 도래자
-            SUM(IIF(DATEDIFF(DAY, GETDATE(), 기간만료일) <![CDATA[<=]]> 15 AND DATEDIFF(DAY, GETDATE(), 기간만료일) >= 0 AND 기간만료일 <![CDATA[<>]]> '' AND 최근상담일 <![CDATA[<>]]> '', 1, 0)) AS dashBoardEXPDate,
+            SUM(IIF(DATEDIFF(DAY, GETDATE(), 기간만료일) <![CDATA[<=]]> 15 AND 기간만료일 <![CDATA[<>]]> '' AND 최근상담일 <![CDATA[<>]]> '', 1, 0))                           AS dashBoardEXPDate,
             -- 초기상담 미실시자
-            SUM(IIF(초기상담일 = '' OR 초기상담일 = null, 1, 0)) AS dashBoardInItCons
+            SUM(IIF(초기상담일 = '', 1, 0)) AS dashBoardInItCons
         FROM J_참여자관리
-        WHERE 전담자_계정 = #{dashboardUserID} AND 지점 = #{dashboardBranch}
-          AND 마감 = 'false'
+        WHERE 전담자_계정 = #{dashboardUserID}
+          AND 지점 = #{dashboardBranch}
+          AND (마감 = 'false' OR 마감 = '')
     </select>
     <!-- 전담자 금일 업무 현황 끝 -->
 </mapper>

--- a/src/main/webapp/WEB-INF/tags/DailyWorkReport.tag
+++ b/src/main/webapp/WEB-INF/tags/DailyWorkReport.tag
@@ -1,0 +1,2 @@
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ tag language="java" pageEncoding="UTF-8" %>

--- a/src/main/webapp/WEB-INF/views/DailyWorkReportPage.jsp
+++ b/src/main/webapp/WEB-INF/views/DailyWorkReportPage.jsp
@@ -72,33 +72,6 @@
     <!-- mouse pointer 모양 bootstrap 5 -->
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" />
 
-    <style>
-        table {
-            border-collapse: collapse;
-            width: 100%;
-            margin-bottom: 20px;
-        }
-        th, td {
-            border: 1px solid #000;
-            padding: 5px;
-            text-align: center;
-            font-size: 12px;
-        }
-        .section-title {
-            background-color: #f0f0f0;
-            font-weight: bold;
-        }
-        .approval-section {
-            text-align: right;
-            margin-bottom: 20px;
-        }
-        .approval-box {
-            display: inline-block;
-            border: 1px solid #000;
-            padding: 10px;
-            margin-left: 10px;
-        }
-    </style>
 </head>
 <body class="layout-fixed sidebar-expand-lg bg-body-tertiary">
 
@@ -115,109 +88,16 @@
             <!--begin::Main content-->
             <div class="container-fluid">
                 <!-- 필요 본문 내용은 이쪽에 만들어 주시면 됩니다. -->
-                <h1>지점 국민취업지원제도 업무진행현황 일일보고</h1>
-
-                <!-- 결재란 -->
-                <div class="approval-section">
-                    <div class="approval-box">
-                        <div>지점관리자</div>
-                        <div style="height: 60px;"></div>
-                    </div>
-                    <div class="approval-box">
-                        <div>대표</div>
-                        <div style="height: 60px;"></div>
-                    </div>
-                    <div class="approval-box">
-                        <div>회장</div>
-                        <div style="height: 60px;"></div>
+                <div class="row">
+                    <div class="col-12">
+                        <a href="/downloadExcel.login" class="button">엑셀 다운로드</a>
                     </div>
                 </div>
 
-                <div>2025년 3월 13일 목요일</div>
+                <div class="row">
+                    <mytag:DailyWorkReport/>
+                </div>
 
-                <!-- 1. 배정 현황 -->
-                <h3>1. 배정 현황</h3>
-                <table>
-                    <tr>
-                        <th colspan="6">2024년 총 서비스 대상 인원(전산 배정 인원)</th>
-                        <th colspan="2">금일 배정인원</th>
-                        <th>상담사 수</th>
-                        <th>평균 배정인원</th>
-                        <th>배정목표</th>
-                    </tr>
-                    <tr>
-                        <td colspan="2">합계</td>
-                        <td colspan="2">Ⅱ유형</td>
-                        <td colspan="2">Ⅰ유형</td>
-                        <td>Ⅱ유형</td>
-                        <td>Ⅰ유형</td>
-                        <td>0</td>
-                        <td>#DIV/0!</td>
-                        <td>100</td>
-                    </tr>
-                </table>
-
-                <!-- 2. 알선취업 성과 현황 -->
-                <h3>2. 알선취업 성과 현황</h3>
-                <table>
-                    <tr>
-                        <th rowspan="2">구분</th>
-                        <th colspan="2">금일 누적 실적</th>
-                        <th colspan="2">금주 누적 실적</th>
-                        <th colspan="2">금월 누적 실적</th>
-                        <th colspan="2">금년 누적 실적</th>
-                    </tr>
-                    <tr>
-                        <th>일반 취업</th>
-                        <th>알선 취업</th>
-                        <th>일반 취업</th>
-                        <th>알선 취업</th>
-                        <th>일반 취업</th>
-                        <th>알선 취업</th>
-                        <th>일반 취업</th>
-                        <th>알선 취업</th>
-                    </tr>
-                    <!-- 상담사별 행 10개 추가 -->
-                    <tr>
-                        <td>합계</td>
-                        <td></td>
-                        <td></td>
-                        <td></td>
-                        <td></td>
-                        <td></td>
-                        <td></td>
-                        <td></td>
-                        <td></td>
-                    </tr>
-                </table>
-
-                <!-- 3. 총괄 진행현황 -->
-                <h3>3. 총괄 진행현황</h3>
-                <table>
-                    <tr>
-                        <th>구분</th>
-                        <th>취소</th>
-                        <th>참여자 합계</th>
-                        <th>현진행자(유예포함)</th>
-                        <th>3단계 진행자</th>
-                        <th>기간만료</th>
-                        <th>중단</th>
-                        <th>성과 불인정 취업</th>
-                        <th>성과 인정 취업</th>
-                        <th>알선취업</th>
-                        <th>평가 취업률</th>
-                        <th>알선취업률</th>
-                        <th>229만원 이상 취업률</th>
-                        <th>고용유지율</th>
-                        <th>조기취업실적</th>
-                        <th>취업인센티브 발생률</th>
-                    </tr>
-                    <!-- 각 연도별 데이터 행 추가 -->
-                </table>
-
-                <!-- 4. 기타사항 -->
-                <h3>4. 기타사항</h3>
-                <textarea style="width: 100%; height: 100px;"></textarea>
             </div>
             <!--end::Main content-->
         </div>

--- a/src/main/webapp/WEB-INF/views/DashBoardPage.jsp
+++ b/src/main/webapp/WEB-INF/views/DashBoardPage.jsp
@@ -171,7 +171,7 @@
                                             </li>
                                             <li class="list-group-item d-flex border-bottom-0">
                                                 <div class="">
-                                                    <div>최근상담일 15일 경과자 ${dailyDashboard.dashBoardLastCons}명</div>
+                                                    <div>최근상담일 21일 경과자 ${dailyDashboard.dashBoardLastCons}명</div>
                                                 </div>
                                             </li>
                                             <li class="list-group-item d-flex border-bottom-0">

--- a/src/main/webapp/WEB-INF/views/UpdateBasicPage.jsp
+++ b/src/main/webapp/WEB-INF/views/UpdateBasicPage.jsp
@@ -160,6 +160,9 @@
                             </div>
                             <%-- 참여자 수정 버튼 끝 --%>
 
+                            <%-- 업데이트 종료 후 이동될 페이지 --%>
+                            <input type="hidden" name="page" value="${param.page}">
+
                             <%-- 참여자 기본정보 입력 tag --%>
                             <mytag:ParticipantBasic basic="${basic}"/>
                         </form>

--- a/src/main/webapp/WEB-INF/views/UpdateCounselPage.jsp
+++ b/src/main/webapp/WEB-INF/views/UpdateCounselPage.jsp
@@ -159,6 +159,9 @@
                             </div>
                             <%-- 참여자 수정 버튼 끝 --%>
 
+                            <%-- 업데이트 종료 후 이동될 페이지 --%>
+                            <input type="hidden" name="page" value="${param.page}">
+
                             <%-- 참여자 상담정보 입력 tag --%>
                             <mytag:ParticipantCounsel counsel="${counsel}"/>
                         </form>

--- a/src/main/webapp/WEB-INF/views/UpdateEmploymentPage.jsp
+++ b/src/main/webapp/WEB-INF/views/UpdateEmploymentPage.jsp
@@ -176,6 +176,8 @@
                                     </button>
                                 </div>
                             </div>
+                            <%-- 업데이트 종료 후 이동될 페이지 --%>
+                            <input type="hidden" name="page" value="${param.page}">
                             <%-- 참여자 수정 버튼 끝 --%>
                             <mytag:ParticipantEmployment employment="${employment}"/>
                         </form>
@@ -288,8 +290,8 @@
             }
 
 
-           const form = $("#newParticipantsForm");
-           form.submit();
+            const form = $("#newParticipantsForm");
+            form.submit();
         });
         <%-- form 전달 끝 --%>
 

--- a/src/main/webapp/WEB-INF/views/UpdateParticipantsPage.jsp
+++ b/src/main/webapp/WEB-INF/views/UpdateParticipantsPage.jsp
@@ -124,6 +124,10 @@
                                     </div>
                                 </div>
                                 <%-- 참여자 수정 버튼 끝 --%>
+
+                                <%-- 업데이트 종료 후 이동될 페이지 --%>
+                                <input type="hidden" name="page" value="${param.page}">
+
                                 <%-- 기본정보 입력 tag --%>
                                 <mytag:ParticipantBasic basic="${basic}"/>
 

--- a/src/main/webapp/WEB-INF/views/participantMain.jsp
+++ b/src/main/webapp/WEB-INF/views/participantMain.jsp
@@ -217,7 +217,10 @@
                                             <tr class="text-center">
                                                 <td><label class="text-center w-100 h-100"><input type="checkbox" class="delete" name="delete" value="${data.participantJobNo}"></label></td>
                                                 <td>${data.participantJobNo}</td>
-                                                <td><a href="/participantUpdate.login?basicJobNo=${data.participantJobNo}">${data.participantPartic}</a></td>
+                                                <td><a
+                                                        href="/participantUpdate.login?basicJobNo=${data.participantJobNo}&page=${param.page == null ? '1' : param.page}">
+                                                        ${data.participantPartic}
+                                                </a></td>
                                                 <td>${data.participantGender}</td>
                                                 <td>${data.participantLastCons}</td>
                                                 <td>${data.participantProgress}</td>
@@ -342,7 +345,7 @@
                 // 현재 버튼의 부모 tr 요소 탐색
                 const number = getJobNumber($(this).closest('tr'));
                 // console.log('/update'+$btn[1]+'?'+$btn[1]+'JobNo=' + number)
-                location.href = '/update' + $btn[1] + '.login?' + $btn[1] + 'JobNo=' + number;
+                location.href = '/update' + $btn[1] + '.login?' + $btn[1] + 'JobNo=' + number + '&page=${param.page == null ? '1' : param.page}';
             });
         })
         <%-- 수정 버튼별 구직번호 전달 스크립트 끝 --%>


### PR DESCRIPTION
- 참여자 페이지 이동 시 페이지 번호 유지 기능 추가
  - JSP 및 자바 컨트롤러의 요청 처리 로직에 `page` 파라미터 추가 및 수정
  - 페이지 전환 시 URL에 `page` 값 포함하도록 구현
- 대시보드 로직 수정: 최근상담일 기준 변경 (15일 → 21일)
  - 관련 XML 매핑 및 JSP 업데이트
- 엑셀 다운로드 기능 구현
  - Apache POI 의존성 추가 (`poi`, `poi-ooxml` 버전 5.3.0)
  - 새로운 컨트롤러 `DailyWorkReport`에 엑셀 생성 및 다운로드 로직 추가
  - 이전 `DailyWorkReportPage.jsp` 코드 단순화, 태그 기반으로 데이터 표기 변경
- 기타 백엔드 스타일 및 데이터매핑 내 SQL 간소화
  - 대시보드 사용자의 필터 조건을 보완하고 중복된 구문 제거