### PR TITLE
지점 실적 데이터 로직 및 상위 20% 점수 통계 추가

### DIFF
--- a/src/main/java/com/jobmoa/app/biz/dashboard/DashboardDTO.java
+++ b/src/main/java/com/jobmoa/app/biz/dashboard/DashboardDTO.java
@@ -115,37 +115,42 @@ public class DashboardDTO {
     private Double employmentOneScore;   //취업자 1인당 점수
     private Double employmentStandardScore;   //표준 취업자 점수
     private Double employmentLastScore;   //가중취업자점수
+    private Double employmentTopScore; // 취업자 점수 상위 20%
     // 알선취업 관련 지표
     private Double placementRate;     // 알선취업률
     private Double placementScore;    // 알선취업자 점수
     private Double placementOneScore; // 알선취업자 1인당 점수
     private Double placementStandardScore; // 표준 알선취업자 점수
     private Double placementLastScore; // 가중알선취업자점수
+    private Double placementTopScore; // 알선취업자점수 상위 20%
     // 조기취업 관련 지표
     private Double earlyEmploymentRate;  // 조기취업률
     private Double earlyEmploymentScore; // 조기취업자 점수
     private Double earlyEmploymentOneScore; // 조기취업자 1인당 점수
     private Double earlyEmploymentStandardScore; // 표준 조기취업자 점수
     private Double earlyEmploymentLastScore; // 가중조기취업자점수
+    private Double earlyEmploymentTopScore; // 조기취업자점수 상위 20%
     // 고용유지 관련 지표
     private Double retentionRate;     // 고용유지율
     private Double retentionScore;    // 고용유지자 점수
     private Double retentionOneScore;    // 고용유지자 1인당 점수
     private Double retentionStandardScore;    // 표준 고용유지자 점수
     private Double retentionLastScore;    // 가중고용취업자점수
+    private Double retentionTopScore;    // 고용취업자점수 상위 20%
     // 나은일자리 관련 지표
     private Double betterJobRate;     // 나은일자리 취업률
     private Double betterJobScore;    // 나은일자리 취업자 점수
     private Double betterJobOneScore;    // 나은일자리 취업자 1인당 점수
     private Double betterJobStandardScore;    // 표준 나은일자리 점수
     private Double betterJobLastScore;    // 가중나은취업자점수
+    private Double betterJobTopScore;    // 나은취업자점수 상위 20%
     // 최종 점수
     private Double totalScore;        // 총점
     private Double totalStandardScore;        // 표준 총점
     //내 점수, 전체지점합계, 전체지점평균, 내지점합계, 내지점평균
     private double myScore; //내 점수
     private double totalBranchScore; //전체지점합계
-    private double totalBranchScoreAVG; //전체지점평균
+    private double totalBranchScoreAVG; //전체지점평균(총 평균)
     private double myBranchScore; //내지점합계
     private double myBranchScoreAVG; //내지점평균
     private String myRanking; //내등급

--- a/src/main/resources/mappings/Dashboard-mapping.xml
+++ b/src/main/resources/mappings/Dashboard-mapping.xml
@@ -453,7 +453,6 @@
         WHERE
             A.전담자_계정 =  #{dashboardUserID}
     </select>
-
     <!-- 지점 평균 및 총점 평균 출력 -->
     <select id="selectBranchAvg" resultType="dashboard">
         WITH 지점순서 AS (
@@ -466,28 +465,6 @@
                 A.지점,
                 A.이름,
                 A.전담자_계정,
-                A.종료자수,
-                A.취업자수,
-                A.특정계층취업자수,
-                A.취업률,
-                A.인당취업자점수,
-                A.알선취업자수,
-                A.알선취업률,
-                A.인당알선취업자수,
-                A.조기취업자수,
-                A.조기취업률,
-                A.인당조기취업자수,
-                A.고용유지자수,
-                A.고용유지취업률,
-                A.인당고용유지점수,
-                A.나은일자리수,
-                A.나은일자리취업률,
-                A.인당나은일자리점수,
-                A.가중취업자점수,
-                A.가중알선취업자점수,
-                A.가중조기취업자점수,
-                A.가중고용취업자점수,
-                A.가중나은취업자점수,
                 A.총점
             FROM 평가실적및점수 A
             JOIN J_참여자관리_로그인정보 L ON A.전담자_계정 = L.아이디
@@ -523,7 +500,202 @@
                  JOIN 지점순서 S ON T.지점 = S.지점
         ORDER BY S.순서
     </select>
-    <!-- 전체, 지점, 내 점수 및 등수 끝 -->
 
+    <!-- 지점별 상담사 실적 점수 데이터 -->
+    <select id="selectBranchConsolScore" resultType="dashboard">
+        WITH 전체점수데이터 AS (
+            SELECT
+                지점, 이름, 전담자_계정,
+                가중취업자점수, 가중알선취업자점수,
+                가중조기취업자점수, 가중고용취업자점수,
+                가중나은취업자점수, 총점
+            FROM 평가실적및점수 A
+            ),
+        총점및인원데이터 AS (
+            SELECT
+            A.지점,
+            SUM(
+                CASE WHEN (
+                        (L.입사일 IS NOT NULL AND L.입사일 > '1900-01-01' AND L.최종발령일 <![CDATA[<=]]> '1900-01-01' AND DATEDIFF(DAY, L.입사일, GETDATE()) >= 365)
+                        OR
+                        (L.최종발령일 IS NOT NULL AND L.최종발령일 > '1900-01-01' AND DATEDIFF(DAY, L.최종발령일, GETDATE()) >= 365)
+                    ) THEN 총점
+                ELSE 0 END) AS 지점_총점,
+            SUM(
+                CASE WHEN (
+                        (L.입사일 IS NOT NULL AND L.입사일 > '1900-01-01' AND L.최종발령일 <![CDATA[<=]]> '1900-01-01' AND DATEDIFF(DAY, L.입사일, GETDATE()) >= 365)
+                        OR
+                        (L.최종발령일 IS NOT NULL AND L.최종발령일 > '1900-01-01' AND DATEDIFF(DAY, L.최종발령일, GETDATE()) >= 365)
+                    ) THEN 1
+                ELSE 0 END) AS 지점_전담자수
+            FROM 전체점수데이터 A
+            LEFT JOIN J_참여자관리_로그인정보 L ON A.전담자_계정 = L.아이디
+            GROUP BY A.지점
+        ),
+        지점_통계 AS (
+            SELECT
+                지점,
+                SUM(총점) AS 지점_총점,
+                COUNT(이름) AS 지점_전담자수
+            FROM 전체점수데이터
+            GROUP BY 지점
+        ),
+        전체_평균 AS (
+            SELECT
+                ROUND(SUM(지점_총점)/NULLIF(SUM(지점_전담자수),0),2) 총평균
+            FROM 총점및인원데이터
+        ),
+        지점_평균_순위 AS (
+            SELECT
+                T.지점,
+                ROUND(T.지점_총점/NULLIF(T.지점_전담자수,0),2) AS 지점_평균,
+                A.총평균
+            FROM 지점_통계 T, 전체_평균 A
+        ),
+        순위_데이터 AS (
+            SELECT
+                RANK() OVER (ORDER BY D.총점 DESC) AS 전체순위,
+                FLOOR(PERCENT_RANK() OVER (ORDER BY D.총점 DESC)*10000)/100 AS 순위_퍼센트,
+                D.이름,
+                D.전담자_계정,
+                D.지점,
+                D.가중취업자점수,
+                D.가중알선취업자점수,
+                D.가중조기취업자점수,
+                D.가중고용취업자점수,
+                D.가중나은취업자점수,
+                D.총점,
+                P.지점_평균,
+                P.총평균,
+            CASE WHEN (
+                (L.입사일 IS NOT NULL AND (L.입사일 > '1900-01-01' AND L.최종발령일 <![CDATA[<=]]> '1900-01-01') AND DATEDIFF(DAY, L.입사일, GETDATE()) >= 365)
+            OR (L.최종발령일 IS NOT NULL AND L.최종발령일 > '1900-01-01' AND DATEDIFF(DAY, L.최종발령일, GETDATE()) >= 365))
+            THEN '1년이상' ELSE '1년미만'
+            END AS 근속기간구분
+            FROM 전체점수데이터 D
+            JOIN 지점_평균_순위 P ON D.지점 = P.지점
+            LEFT JOIN J_참여자관리_로그인정보 L ON D.전담자_계정 = L.아이디
+        )
+        SELECT
+            전체순위,
+            이름 AS dashBoardUserName,
+            전담자_계정 AS dashboardUserID,
+            지점 AS dashboardBranch,
+            가중취업자점수 AS employmentLastScore,
+            가중알선취업자점수 AS placementLastScore,
+            가중조기취업자점수 AS earlyEmploymentLastScore,
+            가중고용취업자점수 AS retentionLastScore,
+            가중나은취업자점수 AS betterJobLastScore,
+            총점 AS totalScore,
+            지점_평균 AS myBranchScoreAVG,
+            총평균 AS totalBranchScoreAVG
+        FROM 순위_데이터
+        WHERE 지점 = #{dashboardBranch}
+    </select>
 
+    <!-- 지점별 상담사 상위 20% 실적 점수 데이터 -->
+    <select id="selectTopConsolScore" resultType="dashboard">
+        WITH
+        전체점수데이터 AS (
+            SELECT
+                지점,
+                이름,
+                전담자_계정,
+                가중취업자점수,
+                가중알선취업자점수,
+                가중조기취업자점수,
+                가중고용취업자점수,
+                가중나은취업자점수,
+                총점
+            FROM 평가실적및점수 A
+        ),
+        총점및인원데이터 AS (
+            SELECT
+            A.지점,
+            SUM(CASE WHEN (
+            (L.입사일 IS NOT NULL AND L.입사일 > '1900-01-01' AND L.최종발령일 <![CDATA[<=]]> '1900-01-01' AND DATEDIFF(DAY, L.입사일, GETDATE()) >= 365)
+            OR
+            (L.최종발령일 IS NOT NULL AND L.최종발령일 > '1900-01-01' AND DATEDIFF(DAY, L.최종발령일, GETDATE()) >= 365))
+                THEN 총점 ELSE 0 END) AS 지점_총점,
+            SUM(CASE WHEN (
+            (L.입사일 IS NOT NULL AND L.입사일 > '1900-01-01' AND L.최종발령일 <![CDATA[<=]]> '1900-01-01' AND DATEDIFF(DAY, L.입사일, GETDATE()) >= 365)
+            OR
+            (L.최종발령일 IS NOT NULL AND L.최종발령일 > '1900-01-01' AND DATEDIFF(DAY, L.최종발령일, GETDATE()) >= 365))
+                THEN 1 ELSE 0 END) AS 지점_전담자수
+            FROM 전체점수데이터 A
+            LEFT JOIN J_참여자관리_로그인정보 L ON A.전담자_계정 = L.아이디
+            GROUP BY A.지점
+        ),
+        지점_통계 AS (
+            SELECT
+                지점,
+                SUM(총점) AS 지점_총점,
+                COUNT(이름) AS 지점_전담자수
+            FROM 전체점수데이터
+            GROUP BY 지점
+        ),
+        전체_평균 AS (
+            SELECT
+                ROUND(SUM(지점_총점)/NULLIF(SUM(지점_전담자수),0),2) 총평균
+            FROM 총점및인원데이터
+        ),
+        지점_평균_순위 AS (
+            SELECT
+                T.지점,
+                ROUND(T.지점_총점/NULLIF(T.지점_전담자수,0),2) AS 지점_평균,
+                A.총평균
+            FROM 지점_통계 T, 전체_평균 A
+        ),
+        순위_데이터 AS (
+            SELECT
+                RANK() OVER (ORDER BY D.총점 DESC) AS 전체순위,
+                FLOOR(PERCENT_RANK() OVER (ORDER BY D.총점 DESC)*10000)/100 AS 순위_퍼센트,
+                D.이름,
+                D.전담자_계정,
+                D.지점,
+                D.가중취업자점수,
+                D.가중알선취업자점수,
+                D.가중조기취업자점수,
+                D.가중고용취업자점수,
+                D.가중나은취업자점수,
+                D.총점,
+                P.지점_평균,
+                P.총평균,
+            CASE WHEN (
+                (L.입사일 IS NOT NULL AND (L.입사일 > '1900-01-01' AND L.최종발령일 <![CDATA[<=]]> '1900-01-01') AND DATEDIFF(DAY, L.입사일, GETDATE()) >= 365)
+            OR (L.최종발령일 IS NOT NULL AND L.최종발령일 > '1900-01-01' AND DATEDIFF(DAY, L.최종발령일, GETDATE()) >= 365))
+            THEN '1년이상'
+            ELSE '1년미만'
+            END AS 근속기간구분
+            FROM 전체점수데이터 D
+            JOIN 지점_평균_순위 P ON D.지점 = P.지점
+            LEFT JOIN J_참여자관리_로그인정보 L ON D.전담자_계정 = L.아이디
+        ),
+        통계_정보 AS (
+            SELECT
+            ROUND(AVG(CASE WHEN 순위_퍼센트 <![CDATA[<=]]> 20 AND 근속기간구분 = '1년이상' THEN 가중취업자점수 END),2) AS 상위20퍼센트_취업자평균,
+            ROUND(AVG(CASE WHEN 근속기간구분 = '1년이상' THEN 가중취업자점수 END),2) AS 전체_취업자평균,
+            ROUND(AVG(CASE WHEN 순위_퍼센트 <![CDATA[<=]]> 20 AND 근속기간구분 = '1년이상' THEN 가중알선취업자점수 END),2) AS 상위20퍼센트_알선평균,
+            ROUND(AVG(CASE WHEN 근속기간구분 = '1년이상' THEN 가중알선취업자점수 END),2) AS 전체_알선평균,
+            ROUND(AVG(CASE WHEN 순위_퍼센트 <![CDATA[<=]]> 20 AND 근속기간구분 = '1년이상' THEN 가중조기취업자점수 END),2) AS 상위20퍼센트_조기평균,
+            ROUND(AVG(CASE WHEN 근속기간구분 = '1년이상' THEN 가중조기취업자점수 END),2) AS 전체_조기평균,
+            ROUND(AVG(CASE WHEN 순위_퍼센트 <![CDATA[<=]]> 20 AND 근속기간구분 = '1년이상' THEN 가중고용취업자점수 END),2) AS 상위20퍼센트_고용평균,
+            ROUND(AVG(CASE WHEN 근속기간구분 = '1년이상' THEN 가중고용취업자점수 END),2) AS 전체_고용평균,
+            ROUND(AVG(CASE WHEN 순위_퍼센트 <![CDATA[<=]]> 20 AND 근속기간구분 = '1년이상' THEN 가중나은취업자점수 END),2) AS 상위20퍼센트_나은평균,
+            ROUND(AVG(CASE WHEN 근속기간구분 = '1년이상' THEN 가중나은취업자점수 END),2) AS 전체_나은평균
+            FROM 순위_데이터
+        )
+        SELECT
+            상위20퍼센트_취업자평균 AS employmentTopScore,
+            전체_취업자평균 AS employmentLastScore,
+            상위20퍼센트_알선평균 AS placementTopScore,
+            전체_알선평균 AS placementLastScore,
+            상위20퍼센트_조기평균 AS earlyEmploymentTopScore,
+            전체_조기평균 AS earlyEmploymentLastScore,
+            상위20퍼센트_고용평균 AS retentionTopScore,
+            전체_고용평균 AS retentionLastScore,
+            상위20퍼센트_나은평균 AS betterJobTopScore,
+            전체_나은평균 AS betterJobLastScore
+        FROM 통계_정보
+    </select>
 </mapper>

--- a/src/main/webapp/WEB-INF/views/DashBoardBranchScoreAndSituation.jsp
+++ b/src/main/webapp/WEB-INF/views/DashBoardBranchScoreAndSituation.jsp
@@ -207,6 +207,7 @@
                         if(clickIndex !== 0){
                             console.log(clickIndex);
                             console.log(branchName);
+                            fetchData(branchName);
                         }
                     }
                 }
@@ -316,6 +317,20 @@
     //     const chart = new ApexCharts(document.querySelector("#distributionChart"), options);
     //     chart.render();
     // }
+
+
+    function fetchData(data){
+        fetch('dashBoardAjaxBranchScore.login', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({dashboardBranch:data})
+        }).then(async response =>
+            console.log(await response.json())
+        )
+    }
+
     $(document).ready(function () {
         changeData(responseData);
 
@@ -333,17 +348,7 @@
             //console.log(changJson);
         }
 
-        function fetchData(data){
-            fetch('dashBoardAjaxBranchScore.login',{
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify(data)
-            }).then(async response =>
-                response.json()
-            )
-        }
+
 
     });
 </script>


### PR DESCRIPTION
- `DashboardDTO`: 취업, 알선, 조기취업, 고용유지, 나은일자리 관련 상위 20% 점수 필드 추가
- `Dashboard-mapping.xml`:
  - 지점 평균 및 전체 평균 로직 수정
  - 지점별 실적 데이터와 상위 20% 점수 데이터 조회 쿼리 추가
- `DashboardAjaxController`:
  - 지점 실적 및 상위 20% 점수 데이터를 조회하고 처리하는 `consolScore` 메소드 추가
  - 세션 검증 로직 및 JSON 변환 로직 포함
- `DashBoardBranchScoreAndSituation.jsp`:
  - 클릭 이벤트에 따른 실적 데이터 fetch 로직 구현
  - `fetchData` 함수 생성 및 호출 로직 수정