### PR TITLE
 커밋 메시지

### DIFF
--- a/src/main/java/com/jobmoa/app/biz/participant/ParticipantDTO.java
+++ b/src/main/java/com/jobmoa/app/biz/participant/ParticipantDTO.java
@@ -32,6 +32,8 @@ public class ParticipantDTO {
     private String participantInItCons; // 초기상담일
     private String participantJobEX; // 구직만료일
     private String participantIAPDate; // IAP수료일
+    private boolean participantIAP3Month; // IAP수료일 3개월 이후 여부
+    private boolean participantIAP5Month; // IAP수료일 5개월 이후 여부
     private String participantStepPro; // 3단계진입일
     private String participantEXPDate; // 기간만료(예정)일
     private String participantClinic; // 클리닉실시일
@@ -63,6 +65,10 @@ public class ParticipantDTO {
 
     //DB 외 정보
     private String participantCondition; // 개발자 구분
+
+    //권한 관리
+    private boolean participantBranchManagement;
+    private boolean participantManagement;
 
     //페이지네이션 정보
     private int page;

--- a/src/main/java/com/jobmoa/app/biz/participantBasic/BasicDTO.java
+++ b/src/main/java/com/jobmoa/app/biz/participantBasic/BasicDTO.java
@@ -30,4 +30,8 @@ public class BasicDTO {
     //DB 외 변수
     private String basicCondition; //개발자 구분
 
+    //권한 관리
+    private boolean basicBranchManagement;
+    private boolean basicManagement;
+
 }

--- a/src/main/java/com/jobmoa/app/view/ajaxPackage/DashboardAjaxController.java
+++ b/src/main/java/com/jobmoa/app/view/ajaxPackage/DashboardAjaxController.java
@@ -115,8 +115,10 @@ public class DashboardAjaxController {
         log.info("consolScore Start Ajax");
         log.info("consolScore Session select Start");
         LoginBean loginBean = (LoginBean)session.getAttribute("JOBMOA_LOGIN_DATA");
-        log.error("consolScore session.getAttribute(\"IS_MANAGER\") : [{}]",session.getAttribute("IS_MANAGER"));
         boolean isManager = (boolean)session.getAttribute("IS_MANAGER");
+        boolean isBranchManager = (boolean)session.getAttribute("IS_BRANCH_MANAGER");
+        log.error("consolScore session.getAttribute(\"IS_MANAGER\") : [{}]",isManager);
+        log.error("consolScore session.getAttribute(\"IS_BRANCH_MANAGER\") : [{}]",isBranchManager);
         String sessionBranch = loginBean.getMemberBranch();
         log.info("consolScore Session select End");
         String branch = dashboardDTO.getDashboardBranch();
@@ -132,16 +134,18 @@ public class DashboardAjaxController {
         log.info("consolScore branchUserScore ChangeJson Start");
         boolean conditionFlag = Boolean.parseBoolean(dashboardDTO.getDashboardCondition());
         log.info("consolScore 고용유지 포함 여부 [{}]",dashboardDTO.isDashboardExcludeRetention());
-        if(!conditionFlag){
+        String selectCondition = (!conditionFlag) ? "selectBranchConsolScore" : "selectBranchConsolScorePerformance";
+
+        if(isManager || isBranchManager){
+            selectCondition+="Manager";
             //잡모아 실적
-            dashboardDTO.setDashboardCondition("selectBranchConsolScore");
-            log.info("consolScore selectBranchConsolScore (잡모아 실적) : [{}]", false);
+            log.info("consolScore selectBranchConsolScore (잡모아 실적 지점 관리자, 관리자 포함) 고용 점수 미포함 여부: [{}]", !conditionFlag);
         }
-        else{
-            //고용부 실적
-            dashboardDTO.setDashboardCondition("selectBranchConsolScorePerformance");
-            log.info("consolScore selectBranchConsolScorePerformance (고용부 실적) : [{}]", true);
-        }
+//        else{
+//            //고용부 실적
+//            log.info("consolScore selectBranchConsolScorePerformance (고용부 실적) : [{}]", true);
+//        }
+        dashboardDTO.setDashboardCondition(selectCondition);
 
         List<DashboardDTO> dashboardDatas = dashboardService.selectAll(dashboardDTO);
         String branchUserScore = changeJson.convertListToJsonArray(dashboardDatas , item ->{

--- a/src/main/java/com/jobmoa/app/view/ajaxPackage/iapBeforeSaveAjax.java
+++ b/src/main/java/com/jobmoa/app/view/ajaxPackage/iapBeforeSaveAjax.java
@@ -1,0 +1,40 @@
+package com.jobmoa.app.view.ajaxPackage;
+
+import com.jobmoa.app.biz.bean.LoginBean;
+import com.jobmoa.app.biz.participant.ParticipantDTO;
+import com.jobmoa.app.biz.participant.ParticipantServiceImpl;
+import jakarta.servlet.http.HttpSession;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+public class iapBeforeSaveAjax {
+
+    @Autowired
+    private ParticipantServiceImpl participantService;
+
+    @PostMapping("/iapBeforeSaveAjax.login")
+    public boolean iapBeforeSaveAjax(@RequestBody ParticipantDTO participantDTO, HttpSession session){
+        LoginBean loginBean = (LoginBean)session.getAttribute("JOBMOA_LOGIN_DATA");
+        String loginId = loginBean.getMemberUserID();
+        boolean branchAdminFlag = (Boolean)session.getAttribute("IS_BRANCH_MANAGER");
+        boolean adminFlag = (Boolean)session.getAttribute("IS_MANAGER");
+
+        //권한 확인을 위해 등록 및 아이디 확인
+        participantDTO.setParticipantUserid(loginId);
+        participantDTO.setParticipantBranchManagement(branchAdminFlag);
+        participantDTO.setParticipantManagement(adminFlag);
+        
+        //지점관리자가 아니거나 관라지 계정이 아니라면
+        //DTO에 아이디를 추가하고 업데이트를 진행한다.
+//        boolean flag = false;
+        participantDTO.setParticipantCondition("iapStatusUpdate");
+
+        return participantService.update(participantDTO);
+    }
+
+}

--- a/src/main/java/com/jobmoa/app/view/dashboard/DashboardMainController.java
+++ b/src/main/java/com/jobmoa/app/view/dashboard/DashboardMainController.java
@@ -261,20 +261,20 @@ public class DashboardMainController {
     @GetMapping("scoreDashboard.login")
     public String scoreDashboard(Model model, HttpSession session, DashboardDTO dashboardDTO){
         LoginBean loginBean = (LoginBean)session.getAttribute("JOBMOA_LOGIN_DATA");
-        boolean isBranchManager = (Boolean)session.getAttribute("IS_BRANCH_MANAGER");
+//        boolean isBranchManager = (Boolean)session.getAttribute("IS_BRANCH_MANAGER");
         boolean isManager = (Boolean)session.getAttribute("IS_MANAGER");
         String userID = loginBean.getMemberUserID();
         String branch = loginBean.getMemberBranch();
 
-        //지점 관리자 ,일반 관리자가 아니라면 지점, 사용자아이디를 추가하고 진행한다.
-        if(!isManager && !isBranchManager){
+        //관리자가 아니라면 지점, 사용자아이디를 추가하고 진행한다.
+        if(!isManager){
             dashboardDTO.setDashboardUserID(userID);
             dashboardDTO.setDashBoardUserBranch(branch);
         }
-        //지점 관리자라면 아이디는 추가하지 않고 진행한다.
-        else if(isBranchManager){
-            dashboardDTO.setDashBoardUserBranch(branch);
-        }
+//        //지점 관리자라면 아이디는 추가하지 않고 진행한다.
+//        else if(isBranchManager){
+//            dashboardDTO.setDashBoardUserBranch(branch);
+//        }
         //상세보기를 클릭하면 DB에 사용자의 각 평가 현황별 % 점수를 반환해준다.
         dashboardDTO.setDashBoardStartDate(this.FAILSTARTDATE);
         dashboardDTO.setDashBoardEndDate(this.FAILENDDATE);

--- a/src/main/java/com/jobmoa/app/view/participant/UpdateController.java
+++ b/src/main/java/com/jobmoa/app/view/participant/UpdateController.java
@@ -50,11 +50,19 @@ public class UpdateController {
     public String updateBasicPage(Model model, HttpSession session, BasicDTO basicDTO, ParticcertifDTO particcertifDTO){
         //session내에 있는 로그인 정보를 불러온다.
         LoginBean loginBean = (LoginBean)session.getAttribute("JOBMOA_LOGIN_DATA");
+        boolean branchAdminFlag = (Boolean)session.getAttribute("IS_BRANCH_MANAGER");
+        boolean adminFlag = (Boolean)session.getAttribute("IS_MANAGER");
+        String loginId = loginBean.getMemberUserID();
+        //각 정보를 조회
+
+        //기본 정보 조회
+        // 로그인 정보에 있는 사용자 아이디를 추가
+        basicDTO.setBasicUserid(loginId);
+        basicDTO.setBasicBranchManagement(branchAdminFlag);
+        basicDTO.setBasicManagement(adminFlag);
         //condition을 추가하여 sql문을 확인할 수 있도록한다.
         basicDTO.setBasicCondition("basicSelectPKONE");
         log.info("loginBean : [{}]", loginBean); // login 정보 로그
-        // 로그인 정보에 있는 사용자 아이디를 추가
-        basicDTO.setBasicUserid(loginBean.getMemberUserID());
         // 구직번호와 맞는 기본정보 하나를 받아온다.
         basicDTO = basicService.selectOne(basicDTO);
 //        log.info("basicDTO : [{}]", basicDTO);
@@ -352,9 +360,14 @@ public class UpdateController {
         //구직번호, 전담자 정보를 변수로 저장
         LoginBean loginBean = (LoginBean)session.getAttribute("JOBMOA_LOGIN_DATA");
         String loginId = loginBean.getMemberUserID();
+        boolean branchAdminFlag = (Boolean)session.getAttribute("IS_BRANCH_MANAGER");
+        boolean adminFlag = (Boolean)session.getAttribute("IS_MANAGER");
         //각 정보를 조회
+
         //기본 정보 조회
         basicDTO.setBasicUserid(loginId);
+        basicDTO.setBasicBranchManagement(branchAdminFlag);
+        basicDTO.setBasicManagement(adminFlag);
         basicDTO.setBasicCondition("basicSelectPKONE");
         basicDTO = basicService.selectOne(basicDTO);
 //        log.info("조회된 기본정로 basicDTO : [{}]", basicDTO);
@@ -369,6 +382,7 @@ public class UpdateController {
             InfoBean.info(model, url, icon, title, message);
             return "views/info";
         }
+
 
         //자격증 정보
         particcertifDTO.setParticcertifJobNo(basicDTO.getBasicJobNo());

--- a/src/main/resources/mappings/Basic-mapping.xml
+++ b/src/main/resources/mappings/Basic-mapping.xml
@@ -5,10 +5,11 @@
     <!-- 기본정보 등록 쿼리문 -->
     <insert id="basicInsert">
         INSERT INTO J_참여자관리
-        (지점, 전담자_계정, 참여자, 생년월일, 성별, 모집경로, 참여유형, 학교명, 전공, 주소, 특정계층, 경력)
+        (지점, 전담자_계정, 초기전담자_계정, 참여자, 생년월일, 성별, 모집경로, 참여유형, 학교명, 전공, 주소, 특정계층, 경력)
         VALUES
         (
          #{basicBranch},
+         #{basicUserid},
          #{basicUserid},
          #{basicPartic},
          #{basicDob},
@@ -100,8 +101,12 @@
             J_참여자관리
         WHERE
             구직번호=#{basicJobNo}
-          AND
-            전담자_계정=#{basicUserid}
+          <choose>
+              <when test="!basicBranchManagement and !basicManagement">
+                  AND
+                  전담자_계정=#{basicUserid}
+              </when>
+          </choose>
     </select>
     
 </mapper>

--- a/src/main/resources/mappings/Dashboard-mapping.xml
+++ b/src/main/resources/mappings/Dashboard-mapping.xml
@@ -586,7 +586,7 @@
         T.지점평균 DESC
     </select>
 
-    <!-- 지점별 상담사 실적 점수 데이터 -->
+    <!-- (지점 관리자 미포함)지점별 상담사 실적 점수 데이터 -->
     <select id="selectBranchConsolScore" resultType="dashboard">
         WITH 전체점수데이터 AS (
             SELECT
@@ -671,6 +671,7 @@
             FROM 전체점수데이터 D
             JOIN 지점_평균_순위 P ON D.지점 = P.지점
             LEFT JOIN J_참여자관리_로그인정보 L ON D.전담자_계정 = L.아이디
+            WHERE L.권한 NOT IN ('팀장','총괄','본부장','이사','차장')
         )
         SELECT
             전체순위,
@@ -689,6 +690,113 @@
             총점 AS totalScore,
             지점_평균 AS myBranchScoreAVG,
             총평균 AS totalBranchScoreAVG
+        FROM 순위_데이터
+        WHERE 지점 = #{dashboardBranch}
+    </select>
+
+    <!-- (지점 관리자 포함)지점별 상담사 실적 점수 데이터 -->
+    <select id="selectBranchConsolScoreManager" resultType="dashboard">
+        WITH 전체점수데이터 AS (
+        SELECT
+        지점, 이름, 전담자_계정,
+        가중취업자점수, 가중알선취업자점수,
+        가중조기취업자점수, 가중나은취업자점수, 총점
+        <choose>
+            <when test="!dashboardExcludeRetention">
+                FROM 평가실적및점수_고용제거 A
+            </when>
+            <otherwise>
+                ,가중고용취업자점수
+                FROM 평가실적및점수 A
+            </otherwise>
+        </choose>
+        ),
+        총점및인원데이터 AS (
+        SELECT
+        A.지점,
+        SUM(
+        CASE WHEN (
+        (L.입사일 IS NOT NULL AND L.입사일 > '1900-01-01' AND L.최종발령일 <![CDATA[<=]]> '1900-01-01' AND DATEDIFF(DAY, L.입사일, GETDATE()) >= 365)
+        OR
+        (L.최종발령일 IS NOT NULL AND L.최종발령일 > '1900-01-01' AND DATEDIFF(DAY, L.최종발령일, GETDATE()) >= 365)
+        ) THEN 총점
+        ELSE 0 END) AS 지점_총점,
+        SUM(
+        CASE WHEN (
+        (L.입사일 IS NOT NULL AND L.입사일 > '1900-01-01' AND L.최종발령일 <![CDATA[<=]]> '1900-01-01' AND DATEDIFF(DAY, L.입사일, GETDATE()) >= 365)
+        OR
+        (L.최종발령일 IS NOT NULL AND L.최종발령일 > '1900-01-01' AND DATEDIFF(DAY, L.최종발령일, GETDATE()) >= 365)
+        ) THEN 1
+        ELSE 0 END) AS 지점_전담자수
+        FROM 전체점수데이터 A
+        LEFT JOIN J_참여자관리_로그인정보 L ON A.전담자_계정 = L.아이디
+        GROUP BY A.지점
+        ),
+        지점_통계 AS (
+        SELECT
+        지점,
+        SUM(총점) AS 지점_총점,
+        COUNT(이름) AS 지점_전담자수
+        FROM 전체점수데이터
+        GROUP BY 지점
+        ),
+        전체_평균 AS (
+        SELECT
+        ROUND(SUM(지점_총점)/NULLIF(SUM(지점_전담자수),0),2) 총평균
+        FROM 총점및인원데이터
+        ),
+        지점_평균_순위 AS (
+        SELECT
+        T.지점,
+        ROUND(T.지점_총점/NULLIF(T.지점_전담자수,0),2) AS 지점_평균,
+        A.총평균
+        FROM 지점_통계 T, 전체_평균 A
+        ),
+        순위_데이터 AS (
+        SELECT
+        RANK() OVER (ORDER BY D.총점 DESC) AS 전체순위,
+        FLOOR(PERCENT_RANK() OVER (ORDER BY D.총점 DESC)*10000)/100 AS 순위_퍼센트,
+        D.이름,
+        D.전담자_계정,
+        D.지점,
+        D.가중취업자점수,
+        D.가중알선취업자점수,
+        D.가중조기취업자점수,
+        <choose>
+            <when test="dashboardExcludeRetention">
+                D.가중고용취업자점수,
+            </when>
+        </choose>
+        D.가중나은취업자점수,
+        D.총점,
+        P.지점_평균,
+        P.총평균,
+        CASE WHEN (
+        (L.입사일 IS NOT NULL AND (L.입사일 > '1900-01-01' AND L.최종발령일 <![CDATA[<=]]> '1900-01-01') AND DATEDIFF(DAY, L.입사일, GETDATE()) >= 365)
+        OR (L.최종발령일 IS NOT NULL AND L.최종발령일 > '1900-01-01' AND DATEDIFF(DAY, L.최종발령일, GETDATE()) >= 365))
+        THEN '1년이상' ELSE '1년미만'
+        END AS 근속기간구분
+        FROM 전체점수데이터 D
+        JOIN 지점_평균_순위 P ON D.지점 = P.지점
+        LEFT JOIN J_참여자관리_로그인정보 L ON D.전담자_계정 = L.아이디
+        )
+        SELECT
+        전체순위,
+        이름 AS dashBoardUserName,
+        전담자_계정 AS dashboardUserID,
+        지점 AS dashboardBranch,
+        가중취업자점수 AS employmentLastScore,
+        가중알선취업자점수 AS placementLastScore,
+        가중조기취업자점수 AS earlyEmploymentLastScore,
+        <choose>
+            <when test="dashboardExcludeRetention">
+                가중고용취업자점수 AS retentionLastScore,
+            </when>
+        </choose>
+        가중나은취업자점수 AS betterJobLastScore,
+        총점 AS totalScore,
+        지점_평균 AS myBranchScoreAVG,
+        총평균 AS totalBranchScoreAVG
         FROM 순위_데이터
         WHERE 지점 = #{dashboardBranch}
     </select>
@@ -821,7 +929,7 @@
     </select>
 
 
-    <!-- 고용부 기준 지점별 상담사 실적 점수 데이터 -->
+    <!-- (지점 관리자 미포함)고용부 기준 지점별 상담사 실적 점수 데이터 -->
     <select id="selectBranchConsolScorePerformance" resultType="dashboard">
         WITH 전체점수데이터 AS (
             SELECT
@@ -838,7 +946,7 @@
                     </otherwise>
                 </choose>
                 ),
-                총점및인원데이터 AS (
+            총점및인원데이터 AS (
                 SELECT
                 A.지점,
                 SUM(
@@ -857,6 +965,7 @@
                 ELSE 0 END) AS 지점_전담자수
             FROM 전체점수데이터 A
             LEFT JOIN J_참여자관리_로그인정보 L ON A.전담자_계정 = L.아이디
+            WHERE 권한 NOT IN ('팀장','총괄','본부장','이사','차장')
             GROUP BY A.지점
         ),
         지점_통계 AS (
@@ -906,6 +1015,7 @@
         FROM 전체점수데이터 D
         JOIN 지점_평균_순위 P ON D.지점 = P.지점
         LEFT JOIN J_참여자관리_로그인정보 L ON D.전담자_계정 = L.아이디
+        WHERE L.권한 NOT IN ('팀장','총괄','본부장','이사','차장')
         )
         SELECT
             전체순위,
@@ -924,6 +1034,113 @@
             총점 AS totalScore,
             지점_평균 AS myBranchScoreAVG,
             총평균 AS totalBranchScoreAVG
+        FROM 순위_데이터
+        WHERE 지점 = #{dashboardBranch}
+    </select>
+
+    <!-- (지점 관리자 포함)고용부 기준 지점별 상담사 실적 점수 데이터 -->
+    <select id="selectBranchConsolScorePerformanceManager" resultType="dashboard">
+        WITH 전체점수데이터 AS (
+        SELECT
+        지점, 이름, 전담자_계정,
+        가중취업자점수, 가중알선취업자점수,
+        가중조기취업자점수, 가중나은취업자점수, 총점
+        <choose>
+            <when test="!dashboardExcludeRetention">
+                FROM 고용부평가실적및점수_고용제거 A
+            </when>
+            <otherwise>
+                ,가중고용취업자점수
+                FROM 고용부평가실적및점수 A
+            </otherwise>
+        </choose>
+        ),
+        총점및인원데이터 AS (
+        SELECT
+        A.지점,
+        SUM(
+        CASE WHEN (
+        (L.입사일 IS NOT NULL AND L.입사일 > '1900-01-01' AND L.최종발령일 <![CDATA[<=]]> '1900-01-01' AND DATEDIFF(DAY, L.입사일, GETDATE()) >= 365)
+        OR
+        (L.최종발령일 IS NOT NULL AND L.최종발령일 > '1900-01-01' AND DATEDIFF(DAY, L.최종발령일, GETDATE()) >= 365)
+        ) THEN 총점
+        ELSE 0 END) AS 지점_총점,
+        SUM(
+        CASE WHEN (
+        (L.입사일 IS NOT NULL AND L.입사일 > '1900-01-01' AND L.최종발령일 <![CDATA[<=]]> '1900-01-01' AND DATEDIFF(DAY, L.입사일, GETDATE()) >= 365)
+        OR
+        (L.최종발령일 IS NOT NULL AND L.최종발령일 > '1900-01-01' AND DATEDIFF(DAY, L.최종발령일, GETDATE()) >= 365)
+        ) THEN 1
+        ELSE 0 END) AS 지점_전담자수
+        FROM 전체점수데이터 A
+        LEFT JOIN J_참여자관리_로그인정보 L ON A.전담자_계정 = L.아이디
+        GROUP BY A.지점
+        ),
+        지점_통계 AS (
+        SELECT
+        지점,
+        SUM(총점) AS 지점_총점,
+        COUNT(이름) AS 지점_전담자수
+        FROM 전체점수데이터
+        GROUP BY 지점
+        ),
+        전체_평균 AS (
+        SELECT
+        ROUND(SUM(지점_총점)/NULLIF(SUM(지점_전담자수),0),2) 총평균
+        FROM 총점및인원데이터
+        ),
+        지점_평균_순위 AS (
+        SELECT
+        T.지점,
+        ROUND(T.지점_총점/NULLIF(T.지점_전담자수,0),2) AS 지점_평균,
+        A.총평균
+        FROM 지점_통계 T, 전체_평균 A
+        ),
+        순위_데이터 AS (
+        SELECT
+        RANK() OVER (ORDER BY D.총점 DESC) AS 전체순위,
+        FLOOR(PERCENT_RANK() OVER (ORDER BY D.총점 DESC)*10000)/100 AS 순위_퍼센트,
+        D.이름,
+        D.전담자_계정,
+        D.지점,
+        D.가중취업자점수,
+        D.가중알선취업자점수,
+        D.가중조기취업자점수,
+        <choose>
+            <when test="dashboardExcludeRetention">
+                D.가중고용취업자점수,
+            </when>
+        </choose>
+        D.가중나은취업자점수,
+        D.총점,
+        P.지점_평균,
+        P.총평균,
+        CASE WHEN (
+        (L.입사일 IS NOT NULL AND (L.입사일 > '1900-01-01' AND L.최종발령일 <![CDATA[<=]]> '1900-01-01') AND DATEDIFF(DAY, L.입사일, GETDATE()) >= 365)
+        OR (L.최종발령일 IS NOT NULL AND L.최종발령일 > '1900-01-01' AND DATEDIFF(DAY, L.최종발령일, GETDATE()) >= 365))
+        THEN '1년이상' ELSE '1년미만'
+        END AS 근속기간구분
+        FROM 전체점수데이터 D
+        JOIN 지점_평균_순위 P ON D.지점 = P.지점
+        LEFT JOIN J_참여자관리_로그인정보 L ON D.전담자_계정 = L.아이디
+        )
+        SELECT
+        전체순위,
+        이름 AS dashBoardUserName,
+        전담자_계정 AS dashboardUserID,
+        지점 AS dashboardBranch,
+        가중취업자점수 AS employmentLastScore,
+        가중알선취업자점수 AS placementLastScore,
+        가중조기취업자점수 AS earlyEmploymentLastScore,
+        <choose>
+            <when test="dashboardExcludeRetention">
+                가중고용취업자점수 AS retentionLastScore,
+            </when>
+        </choose>
+        가중나은취업자점수 AS betterJobLastScore,
+        총점 AS totalScore,
+        지점_평균 AS myBranchScoreAVG,
+        총평균 AS totalBranchScoreAVG
         FROM 순위_데이터
         WHERE 지점 = #{dashboardBranch}
     </select>

--- a/src/main/resources/mappings/Participant-mapping.xml
+++ b/src/main/resources/mappings/Participant-mapping.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="ParticipantDAO">
-    <!-- 기본 쿼리 시작 -->
+    <!-- 상담관리 기본 쿼리 시작 -->
     <select id="selectAllParticipantBasic" resultType="participant">
         SELECT TOP (#{pageRows})
             구직번호 AS participantJobNo,
@@ -10,6 +10,9 @@
             성별 AS participantGender,
             최근상담일 AS participantLastCons,
             상담경과일 AS participantAdventCons,
+            IAP수료일 AS participantIAPDate,
+            IAP3개월여부 AS participantIAP3Month,
+            IAP5개월여부 AS participantIAP5Month,
             진행단계 AS participantProgress,
             생년월일 AS participantDob,
             초기상담일 AS participantInItCons,
@@ -58,6 +61,9 @@
                         WHEN 최근상담일 <![CDATA[<>]]> '' AND 마감='false' THEN DATEDIFF(DAY, 최근상담일, GETDATE())
                         END AS 상담경과일,
                     간접고용서비스,
+                    IAP수료일,
+                    IAP3개월여부,
+                    IAP5개월여부,
                     마감
                  FROM J_참여자관리
                  WHERE
@@ -144,9 +150,9 @@
         </choose>
 
     </select>
-    <!-- 기본 쿼리 끝 -->
+    <!-- 상담관리 기본 쿼리 끝 -->
 
-    <!-- 검색 쿼리 시작 -->
+    <!-- 상담관리 검색 쿼리 시작 -->
     <select id="selectAllParticipantSearch" resultType="participant">
         SELECT TOP (#{pageRows})
             구직번호 AS participantJobNo,
@@ -154,6 +160,9 @@
             성별 AS participantGender,
             최근상담일 AS participantLastCons,
             상담경과일 AS participantAdventCons,
+            IAP수료일 AS participantIAPDate,
+            IAP3개월여부 AS participantIAP3Month,
+            IAP5개월여부 AS participantIAP5Month,
             진행단계 AS participantProgress,
             생년월일 AS participantDob,
             초기상담일 AS participantInItCons,
@@ -203,6 +212,9 @@
                         THEN DATEDIFF(DAY, 최근상담일, GETDATE())
                         END AS 상담경과일,
                      간접고용서비스,
+                     IAP수료일,
+                     IAP3개월여부,
+                     IAP5개월여부,
                      마감
                  FROM J_참여자관리
                  WHERE
@@ -290,7 +302,7 @@
             </when>
         </choose>
     </select>
-    <!-- 검색 쿼리 끝 -->
+    <!-- 상담관리 검색 쿼리 끝 -->
 
     <!-- 참여자 전체 자격증 확인용 쿼리 시작 -->
     <select id="selectOneParticcertif" resultType="participant">
@@ -456,6 +468,9 @@
         최근상담일 AS participantLastCons,
         상담경과일 AS participantAdventCons,
         진행단계 AS participantProgress,
+        IAP수료일 AS participantIAPDate,
+        IAP3개월여부 AS participantIAP3Month,
+        IAP5개월여부 AS participantIAP5Month,
         생년월일 AS participantDob,
         초기상담일 AS participantInItCons,
         간접고용서비스 AS participantEmploymentService,
@@ -508,6 +523,9 @@
         THEN DATEDIFF(DAY, A.최근상담일, GETDATE())
         END AS 상담경과일,
         A.간접고용서비스,
+        A.IAP수료일,
+        A.IAP3개월여부,
+        A.IAP5개월여부,
         A.마감
         FROM J_참여자관리 A
         JOIN J_참여자관리_로그인정보 B
@@ -605,6 +623,9 @@
         성별 AS participantGender,
         최근상담일 AS participantLastCons,
         상담경과일 AS participantAdventCons,
+        IAP수료일 AS participantIAPDate,
+        IAP3개월여부 AS participantIAP3Month,
+        IAP5개월여부 AS participantIAP5Month,
         진행단계 AS participantProgress,
         생년월일 AS participantDob,
         초기상담일 AS participantInItCons,
@@ -658,6 +679,9 @@
         THEN DATEDIFF(DAY, A.최근상담일, GETDATE())
         END AS 상담경과일,
         A.간접고용서비스,
+        A.IAP수료일,
+        A.IAP3개월여부,
+        A.IAP5개월여부,
         A.마감
         FROM J_참여자관리 A
         JOIN J_참여자관리_로그인정보 B
@@ -892,5 +916,22 @@
     </select>
     <!-- 서비스 미제공 상담사 검색 끝 -->
 
+    <!-- IAP 수립일 3,5개월 여부 update 쿼리 시작 -->
+    <update id="iapStatusUpdate">
+        UPDATE
+            J_참여자관리
+        set
+            IAP3개월여부 = #{participantIAP3Month},
+            IAP5개월여부 = #{participantIAP5Month}
+        WHERE
+            구직번호 = #{participantJobNo}
+            <choose>
+                <when test="!participantBranchManagement and !participantManagement">
+                    AND
+                    전담자_계정 = #{participantUserid}
+                </when>
+            </choose>
+    </update>
+    <!-- IAP 수립일 3,5개월 여부 update 쿼리 끝 -->
 
 </mapper>

--- a/src/main/webapp/WEB-INF/views/DashBoardPage.jsp
+++ b/src/main/webapp/WEB-INF/views/DashBoardPage.jsp
@@ -250,6 +250,7 @@
                                             <div class="flex-grow-1 d-flex align-items-start justify-content-end">
                                                 <a
                                                         class="btn btn-outline-secondary btn-sm text-center"
+<%--                                                        onclick="alert('제작중인 페이지입니다.')"--%>
                                                         href="${IS_MANAGER? "scoreBranchDashboard.login":"scoreDashboard.login"}">
                                                     상세정보
                                                 </a>
@@ -289,7 +290,7 @@
                             <div class="col-md-10 pt-2 pb-2 h2 me-auto">
                                 <div class="row">
                                     <div class="col-md-10">
-                                        나의 KPI 달성률
+                                        개인 실적 달성률
                                     </div>
                                     <div class="col-md-2">
                                         <%--<div class="row h2 ps-3">
@@ -594,34 +595,34 @@
         let trueCaseNum = ${empty myKPI.trueCaseNum ? 0 : myKPI.trueCaseNum}; // 인센 해당
         console.log("trueCaseNum : "+ trueCaseNum);
 
-        let colors = ['#0064A600','#0064a6']
+        let colors = ['#0064a6','#0064A600']
 
         //배정 인원 차트
-        let series = [95-assignedParticipants, assignedParticipants]
+        let series = [assignedParticipants, 95-assignedParticipants]
         let labels = ['남은 목표', '배정 인원']
         let donut = new ApexCharts(document.querySelector("#exemple"), apexChartDoughnut('배정인원(목표:95)',series, labels,colors));
         donut.render();
 
         //종료 취업자 차트
-        series = [65-employmentRate, employmentRate]
+        series = [employmentRate, 65-employmentRate]
         labels = ['남은 목표', '종료 취업자']
         donut = new ApexCharts(document.querySelector("#terminatedEmploymentChart"), apexChartDoughnut('종료 취업자',series, labels,colors));
         donut.render();
 
         //알선 취업자 차트
-        series = [65-placementRate, placementRate]
+        series = [placementRate, 65-placementRate]
         labels = ['남은 목표', '알선 취업자']
         donut = new ApexCharts(document.querySelector("#referralEmploymentChart"), apexChartDoughnut('알선 취업자',series, labels,colors));
         donut.render();
 
         //조기 취업자 차트
-        series = [65-earlyEmploymentRate, earlyEmploymentRate]
+        series = [earlyEmploymentRate, 65-earlyEmploymentRate]
         labels = ['남은 목표', '조기 취업자']
         donut = new ApexCharts(document.querySelector("#earlyEmploymentChart"), apexChartDoughnut('조기 취업자',series, labels,colors));
         donut.render();
 
         //나은일자리 차트
-        series = [65-betterJobRate, betterJobRate]
+        series = [betterJobRate, 65-betterJobRate]
         labels = ['남은 목표', '나은일자리']
         donut = new ApexCharts(document.querySelector("#betterJobChart"), apexChartDoughnut('나은일자리',series, labels,colors));
         donut.render();
@@ -921,8 +922,9 @@
                         const clickIndex = config.dataPointIndex;
                         // const branchName = Datas.thisSuccess.branch[branchIndex];
 
-                        // 전체 지점 클릭시 모달 표시
+                        // 전체 지점 클릭시 모달 표시 or 페이지이동
                         if (clickIndex === 1) {
+                            // alert('제작중입니다.')
                             location.href = "scoreBranchDashboard.login";
                         }
                     }

--- a/src/main/webapp/WEB-INF/views/transferPage.jsp
+++ b/src/main/webapp/WEB-INF/views/transferPage.jsp
@@ -73,6 +73,10 @@
     <!-- mouse pointer 모양 bootstrap 5 -->
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" />
 
+    <!-- sweetalert2 -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/sweetalert2@11.4.10/dist/sweetalert2.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11.4.10/dist/sweetalert2.min.js"></script>
+    <script src="js/sweetAlert.js"></script>
 
     <style>
         .transfer-buttons {
@@ -480,18 +484,30 @@
 
         // 선택 이전 버튼 클릭
         $('#transferSelected').click(function() {
-            transferParticipants(Array.from(selectedParticipants));
+            alertConfirmWarning('선택한 참여자를 이전합니다.', '이전 후 복구는 불가능합니다.', '이전', '취소').then(function(result) {
+                if (result) {
+                    transferParticipants(Array.from(selectedParticipants));
+                }
+                else {
+                    $selectAllSource.prop('checked', false);
+                }
+            });
         });
 
         // 전체 이전 버튼 클릭
         $('#transferAll').click(function() {
-            $selectAllSource.prop('checked', true);
-            changeAllParticipants();
-            // const allParticipants = $('.participant-check').map(function() {
-            //     return $(this).val();
-            // }).get();
-            console.log(Array.from(selectedParticipants));
-            transferParticipants(Array.from(transferredParticipants));
+
+            alertConfirmWarning('참여자 전체를 이전합니다.', '이전 후 복구는 불가능합니다.', '이전', '취소').then(function(result) {
+               if (result) {
+                   $selectAllSource.prop('checked', true);
+                   changeAllParticipants();
+                   console.log(Array.from(selectedParticipants));
+                   transferParticipants(Array.from(transferredParticipants));
+               }
+               else {
+                   $selectAllSource.prop('checked', false);
+               }
+            });
         });
 
         function updateSelectedParticipants() {

--- a/src/main/webapp/js/ApexChartMainDashBoardJS.js
+++ b/src/main/webapp/js/ApexChartMainDashBoardJS.js
@@ -59,8 +59,8 @@ function apexChartDoughnut(title,series,labels, colors) {
             },
             formatter: function(val, opts) {
 
-                // 두 번째 시리즈의 dataLabel을 숨김
-                if (series.length == 2 && opts.seriesIndex === 0) {
+                // 첫 번째 시리즈의 dataLabel을 숨김
+                if (series.length == 2 && opts.seriesIndex === 1) {
                     return '';
                 }
 


### PR DESCRIPTION
**지점 실적 데이터 처리 로직 수정 및 분리**

- JavaScript 코드에서 잘못된 데이터 레이블 표시 조건 수정: 기존: 첫 번째 시리즈 표시 조건 -> 수정: 첫 번째 시리즈 숨김 조건

- `Dashboard-mapping.xml` 주요 변경 사항:
  * 지점별 상담사 실적 점수 데이터를 "지점 관리자 포함" / "지점 관리자 미포함"으로 각각 분리
  * 고용부 기준 실적 데이터 또한 위와 동일하게 "포함" / "미포함"으로 구조를 세분화하여 쿼리 추가
  * 다양한 통계 결과를 계산하는 위드(With) 구문 추가 및 확장
    - 총점 및 전담자 수 계산 로직 상세화
    - 근속 기간 1년 이상/미만 구분 로직 반영

- 전체적으로 데이터 필터링 조건과 로직을 재정의하며 가독성 및 유지보수를 위한 주석 개선 및 추가.

> **주요 목적:** 데이터 처리 로직의 정확성과 효율성 향상 및 필터링에 따른 데이터 세분화 반영.